### PR TITLE
Add yapf pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,11 @@ autoreduce*/
 ansible/
 kibana*/
 
+# Ignore virtual environment
+venv/
+venv3/
+venv36/
+venv37/
+
 # Ignore IDE files
 .idea/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.31.0  # Keep this version up to date with requirements.txt
+    hooks:
+      - id: yapf
+        args: ['--in-place', '--parallel', '--recursive']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+yapf==0.31.0  # Keep this version up to date with .pre-commit-config.yaml
+pre-commit==2.12.1

--- a/runme.sh
+++ b/runme.sh
@@ -10,3 +10,12 @@ git clone https://github.com/ISISScientificComputing/ansible
 git clone https://github.com/ISISScientificComputing/autoreduce
 git clone https://github.com/ISISScientificComputing/autoreduce-rest-api
 git clone https://github.com/ISISScientificComputing/autoreduce-notebooks
+
+# Setup pre-commit hooks for cloned repositories
+pip install -r requirements.txt
+for d in */; do
+  if [[ $d != *"venv"* ]]; then # skip setting up pre-commit hook in *venv* directory
+    cp -v .pre-commit-config.yaml "$d" && (cd "$d" && pre-commit install)
+  fi
+done
+


### PR DESCRIPTION
### Summary of work
- Added yapf pre-commit hook for checked out repositories.

### How to test your work
- `cd` into one of the cloned repositories.
- Add some incorrectly formatted Python code.
- Stage the file. And try to commit it.
- It should fail to commit and also fix the file.
- Stage the file again. And commit without the hook failing.
- To manually run the hook without committing run `pre-commit run`

### Additional comments
* If you can't think of a easier solution, I will add the `.pre-commit-config.yaml` to all the `.gitignore` files in the cloned repositories.
* There's also the opportunity to add [other hooks](https://pre-commit.com/hooks.html).
* `pylint` might be useful to run after yapf but I couldn't get it to work. I tried below (and variations on it) but it always seems to hang or not find the right python modules:
```yml
  - repo: https://github.com/PyCQA/pylint
    rev: v2.8.2
    hooks:
      - id: pylint
        entry: env PYTHONPATH=autoreduce_qp pylint
        additional_dependencies: [pylint-django]
        args: ['--load-plugins=pylint_django autoreduce_qp']
```