### PR TITLE
Tidy workspace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-  - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.32.0  # Keep this version up to date with requirements.txt
-    hooks:
-      - id: yapf
-        args: ['--in-place', '--parallel', '--recursive']

--- a/autoreduce.code-workspace
+++ b/autoreduce.code-workspace
@@ -19,6 +19,9 @@
 			"path": "./k8s"
 		},
 		{
+			"path": "./k8s-infra"
+		},
+		{
 			"path": "./actions"
 		},
 		{

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-yapf==0.32.0  # Keep this version up to date with .pre-commit-config.yaml
-pre-commit==2.17.0

--- a/runme.sh
+++ b/runme.sh
@@ -9,7 +9,6 @@ git clone https://github.com/autoreduction/scripts
 git clone https://github.com/autoreduction/ansible
 git clone https://github.com/autoreduction/queue-processor
 git clone https://github.com/autoreduction/k8s
+git clone https://github.com/autoreduction/k8s-infra
 git clone https://github.com/autoreduction/rest-api
 git clone https://github.com/autoreduction/notebooks
-
-


### PR DESCRIPTION
# Changes

- Remove unused and deprecated pre-commit + corresponding requirements (relic from when a single pre-commit-config was copied into each repo folder when runme.sh was run - this functionality was removed in [this commit](https://github.com/autoreduction/workspace/commit/b892c5855d97185e85abb0116182f1509d31db25) ).
- Clone k8s-infra alongside k8s so repo doesn't have to be cloned manually
